### PR TITLE
Set MYSQL_RANDOM_ROOT_PASSWORD to "yes" instead of "random"

### DIFF
--- a/src/modules/ROOT/examples/docker-compose/basic/docker-compose.yaml
+++ b/src/modules/ROOT/examples/docker-compose/basic/docker-compose.yaml
@@ -54,5 +54,5 @@ services:
       MYSQL_DATABASE: dbname
       MYSQL_USER:     dbuser
       MYSQL_PASSWORD: dbpass
-      MYSQL_RANDOM_ROOT_PASSWORD: random # docker-compose logs db |grep "GENERATED ROOT PASSWORD"
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes" # docker-compose logs db |grep "GENERATED ROOT PASSWORD"
     healthcheck: { test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"], timeout: 20s, retries: 10 }


### PR DESCRIPTION
The [documentation](https://hub.docker.com/r/percona/percona-server) of percona described the value for `MYSQL_RANDOM_ROOT_PASSWORD` should be a boolean. Quoted to prevent docker-compose from complaining. (`services.db.environment.MYSQL_RANDOM_ROOT_PASSWORD contains true, which is an invalid type, it should be a string, number, or a null`)