### PR TITLE
Devops Discovery multi-image docker examples

### DIFF
--- a/src/modules/devops-guide/examples/deploy/prod-discovery-pgsql/docker-compose.yaml
+++ b/src/modules/devops-guide/examples/deploy/prod-discovery-pgsql/docker-compose.yaml
@@ -1,0 +1,56 @@
+version: '3.5'
+
+services:
+  server:
+    image: cortezaproject/corteza:${VERSION}
+    env_file: [ .env ]
+    depends_on: [ db ]
+    networks: [ proxy, internal ]
+    environment:
+      VIRTUAL_HOST:     ${DOMAIN}
+      LETSENCRYPT_HOST: ${DOMAIN}
+    volumes: [ "./data/server:/data" ]
+    restart: on-failure
+
+  db:
+    image: postgres:13
+    networks: [ internal ]
+    restart: on-failure
+    healthcheck: { test: ["CMD-SHELL", "pg_isready -U corteza"], interval: 10s, timeout: 5s, retries: 5 }
+    environment:
+      POSTGRES_USER:     corteza
+      POSTGRES_PASSWORD: corteza
+
+  es:
+    image: opensearchproject/opensearch:1.3.0
+    restart: on-failure
+    networks: [ internal ]
+    environment:
+      - cluster.name=es-docker-cluster
+      - node.name=es
+      - cluster.initial_master_nodes=es
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - OPENSEARCH_JAVA_OPTS=-Xms8000m -Xmx8000m # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - DISABLE_SECURITY_PLUGIN=true
+      - VIRTUAL_HOST=es.${DOMAIN}
+      - LETSENCRYPT_HOST=es.${DOMAIN}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - ./data/es:/usr/share/elasticsearch/data
+
+  discovery:
+    image: cortezaproject/corteza-server-discovery:${VERSION}
+    restart: on-failure
+    env_file: [ .env ]
+    depends_on: [ es, server ]
+    networks: [ proxy, internal ]
+    environment:
+      VIRTUAL_HOST: discovery.${DOMAIN}
+      VIRTUAL_PORT: 80
+      LETSENCRYPT_HOST: discovery.${DOMAIN}
+
+networks: { internal: {}, proxy: { name: proxy } }

--- a/src/modules/devops-guide/examples/deploy/prod-discovery-pgsql/env-example.txt
+++ b/src/modules/devops-guide/examples/deploy/prod-discovery-pgsql/env-example.txt
@@ -1,0 +1,40 @@
+########################################################################################################################
+# General settings
+DOMAIN=your-demo.example.tld
+VERSION=2022.3.0
+
+########################################################################################################################
+# Database connection
+
+DB_DSN=postgres://corteza:corteza@db:5432/corteza?sslmode=disable
+
+########################################################################################################################
+# Server settings
+
+# Serve Corteza webapps alongside API
+HTTP_WEBAPP_ENABLED=true
+
+########################################################################################################################
+# Server Discovery configs
+
+DISCOVERY_ENABLED=true
+DISCOVERY_DEBUG=true
+DISCOVERY_CORTEZA_DOMAIN=https://your-demo.example.tld
+DISCOVERY_BASE_URL=//discovery.your-demo.example.tld
+CORTEZA_SERVER_BASE_URL=http://server:80
+
+ES_ADDRESS=http://es:9200
+ES_INDEX_INTERVAL=300
+HTTP_ADDR=0.0.0.0:80
+
+# Corteza Discovery indexer configuration
+DISCOVERY_INDEXER_ENABLED=true
+DISCOVERY_INDEXER_PRIVATE_INDEX_CLIENT_KEY=${PRIVATE_KEY_EXAMPLE}
+DISCOVERY_INDEXER_PRIVATE_INDEX_CLIENT_SECRET=${SECRET_EXAMPLE}
+
+# Corteza Discovery searcher configuration
+DISCOVERY_SEARCHER_ENABLED=true
+DISCOVERY_SEARCHER_CLIENT_KEY=${CLIENT_KEY_EXAMPLE}
+DISCOVERY_SEARCHER_CLIENT_SECRET=${CLIENT_SECRET_EXAMPLE}
+DISCOVERY_SEARCHER_JWT_SECRET=${JWT_SECRET_EXAMPLE}
+DISCOVERY_SEARCHER_ALLOWED_ROLE=${ROLE_ALLOWED_EXAMPLE}

--- a/src/modules/devops-guide/pages/discovery/index.adoc
+++ b/src/modules/devops-guide/pages/discovery/index.adoc
@@ -19,7 +19,7 @@ To access the Docker container, run the following command:
 
 [source,bash]
 ----
-docker-compose exec server sh
+docker-compose exec server bash
 ----
 ====
 
@@ -56,45 +56,7 @@ DISCOVERY_BASE_URL=your-discovery-server-base-url
 # DISCOVERY_DEBUG=true
 ----
 
-== Configuring {PRODUCT_NAME} {APP_NAME_DISCOVERY} Server
-
-.Example `.env` file for for your {PRODUCT_NAME} {APP_NAME_DISCOVERY} server:
-[source,env]
-----
-AUTH_CLIENT_KEY=your-client-key-here
-AUTH_CLIENT_SECRET=your-client-secret-here
-
-########################################################################################################################
-########################################################################################################################
-# Corteza Discovery configuration
-CORTEZA_SERVER_BASE_URL=your-corteza-server-base-url
-
-# Adjust log level to your needs
-LOG_LEVEL=debug
-
-ES_ADDRESS=your-elastic/open-search-base-url
-# Reindex interval in seconds
-ES_INDEX_INTERVAL=10
-
-DOMAIN=your-domain-here
-HTTP_ADDR=your-domain-here
-
-########################################################################################################################
-########################################################################################################################
-# Corteza Discovery indexer configuration
-
-DISCOVERY_INDEXER_ENABLED=true
-
-DISCOVERY_INDEXER_PRIVATE_INDEX_CLIENT_KEY=${AUTH_CLIENT_KEY}
-DISCOVERY_INDEXER_PRIVATE_INDEX_CLIENT_SECRET=${AUTH_CLIENT_SECRET}
-
-
-########################################################################################################################
-########################################################################################################################
-# Corteza Discovery searcher configuration
-
-DISCOVERY_SEARCHER_ENABLED=true
-DISCOVERY_SEARCHER_CLIENT_KEY=${AUTH_CLIENT_KEY}
-DISCOVERY_SEARCHER_CLIENT_SECRET=${AUTH_CLIENT_SECRET}
-DISCOVERY_SEARCHER_JWT_SECRET=some-random-value-here
-----
+[NOTE]
+====
+For an example of an online deployment, refer to xref:devops-guide:deploy-online/multi-discovery-pgsql.adoc[].
+====

--- a/src/modules/devops-guide/pages/examples/deploy-online/index.adoc
+++ b/src/modules/devops-guide/pages/examples/deploy-online/index.adoc
@@ -6,6 +6,8 @@ include::./multi-mysql.adoc[]
 
 include::./multi-pgsql.adoc[]
 
+include::./multi-discovery-pgsql.adoc[]
+
 // include::./single-mysql.adoc[]
 
 // include::./single-pgsql.adoc[]

--- a/src/modules/devops-guide/pages/examples/deploy-online/multi-discovery-pgsql.adoc
+++ b/src/modules/devops-guide/pages/examples/deploy-online/multi-discovery-pgsql.adoc
@@ -1,0 +1,20 @@
+= Multi-image Discovery with PostgreSQL
+:page-noindex: true
+
+[NOTE]
+====
+Currently Corteza Discovery is tested on a running production servers in combination with PostgreSQL database, but should work with the latest MySQL versions.
+Beside the `server` and `db` containers, there should be also the indexer (`es`) and the searcher (`discovery`) running.
+====
+
+.`docker-compose.yaml`
+[source,yaml]
+----
+include::example$deploy/prod-discovery-pgsql/docker-compose.yaml[]
+----
+
+.`.env`
+[source,env]
+----
+include::example$deploy/prod-discovery-pgsql/env-example.txt[]
+----

--- a/src/modules/devops-guide/pages/examples/deploy-online/multi-mysql.adoc
+++ b/src/modules/devops-guide/pages/examples/deploy-online/multi-mysql.adoc
@@ -14,7 +14,7 @@ include::example$deploy/prod-mysql/docker-compose.yaml[]
 ----
 
 .`.env`
-[source,yaml]
+[source,env]
 ----
 include::example$deploy/prod-mysql/env-example.txt[]
 ----

--- a/src/modules/devops-guide/pages/examples/deploy-online/multi-pgsql.adoc
+++ b/src/modules/devops-guide/pages/examples/deploy-online/multi-pgsql.adoc
@@ -14,7 +14,7 @@ include::example$deploy/prod-pgsql/docker-compose.yaml[]
 ----
 
 .`.env`
-[source,yaml]
+[source,env]
 ----
 include::example$deploy/prod-pgsql/env-example.txt[]
 ----


### PR DESCRIPTION
What:
 - removed an old `.env` example that I think it was missing some info (@vicpatel please advise)
 - added a link to the examples from the main Discovery doc
 - added docker compose and `.env` examples