### PR TITLE
Updated broken gotenberg link in docs

### DIFF
--- a/src/modules/integrator-guide/pages/index.adoc
+++ b/src/modules/integrator-guide/pages/index.adoc
@@ -76,7 +76,7 @@ Refer to xref:discovery/index.adoc[] page to learn how to configure and use {PRO
 
 [IMPORTANT]
 ====
-To enable PDF document rendering, you will need to run the https://thecodingmachine.github.io/gotenberg/[gotenberg] Docker container.
+To enable PDF document rendering, you will need to run the https://thecodingmachine.io/gotenberg-a-stateless-api-for-converting-files-to-pdf/[gotenberg] Docker container.
 
 Refer to the xref:devops-guide:pdf-renderer.adoc[DevOps guide] for details on how to set it up.
 ====


### PR DESCRIPTION
Updated link to what I believe is the correct, current link. Fixes #351 