### PR TITLE
Stop 'view' omission from crashing builds

### DIFF
--- a/lib/annotation-preprocessor/annotate.js
+++ b/lib/annotation-preprocessor/annotate.js
@@ -1,7 +1,11 @@
 const box = require('./anni-box')
 const { image } = require('./styleguide')
 
-function wrapSVG (cfg, img, annotations) {
+function wrapSVG(cfg, img, annotations) {
+   if (!cfg.view) {
+      cfg.view = {}
+   }
+
    const wb = {
       x: cfg.view.x || 0,
       y: cfg.view.y || 0,


### PR DESCRIPTION
This ensures that omitting the 'view' property from image annotating does not crash builds any longer.