### PR TITLE
translation environment variables

### DIFF
--- a/src/modules/devops-guide/pages/i18n/index.adoc
+++ b/src/modules/devops-guide/pages/i18n/index.adoc
@@ -128,6 +128,8 @@ If you want to define multiple languages, you need to separate them with a comma
 LOCALE_LANGUAGES="en,de,it"
 ----
 
+To enable translations for your {PRODUCT_NAME} {APP_NAME_COMPOSE} custom content, you have to set `LOCALE_RESOURCE_TRANSLATIONS_ENABLED=true`.
+
 == Development Environment
 
 {PRODUCT_NAME} provides some helpful utilities for debugging and general translations, which can be enabled with the following `.env` variables.

--- a/src/modules/integrator-guide/pages/i18n/resource.adoc
+++ b/src/modules/integrator-guide/pages/i18n/resource.adoc
@@ -27,6 +27,8 @@ Generally, only the resources accessible by end-users support resource translati
 
 The resource translations user interface can be accessed by clicking on the *language* {ICON_I18N} button when editing the resource that supports this feature.
 
+To enable this, set `LOCALE_RESOURCE_TRANSLATIONS_ENABLED=true` as an environment variable.
+Resources translations can currently only use the languages defined in the `LOCALE_LANGUAGES` environment variable.
 
 [annotation,role="data-zoomable"]
 ----

--- a/src/modules/integrator-guide/pages/i18n/static.adoc
+++ b/src/modules/integrator-guide/pages/i18n/static.adoc
@@ -10,6 +10,17 @@ Static translations are button labels, system page titles, and error messages.
 
 Refer to xref:i18n/resource.adoc[resource translations] to learn how to translate configurable content.
 
+== Enabling languages
+
+The list of enabled languages is defined by the `LOCALE_LANGUAGES` environment variable.
+Use a single language code or a comma-separated list of language codes.
+
+.An example configuration that uses English, German, and Italian languages:
+[source]
+----
+LOCALE_LANGUAGES="en,de,it"
+----
+
 == Modify static translations
 
 === Fork the corteza-locale repository


### PR DESCRIPTION
As discussed on the [forum](https://forum.cortezaproject.org/t/missing-language-translation-button-bug/2536/4), here is a PR that adds mentions of `LOCALE_LANGUAGES` and `LOCALE_RESOURCE_TRANSLATIONS_ENABLED` that would have helped me a few days ago.

---

The "Resources translations can currently only use the languages defined in the `LOCALE_LANGUAGES` environment variable." information was inspired by this:

https://github.com/cortezaproject/corteza/blob/a42eefd935060bcfa4ff2e824e2b4801382457c3/server/system/types/app_settings.go#L302