### PR TITLE
Update incorrect Go version number

### DIFF
--- a/src/modules/developer-guide/pages/corteza-server/index.adoc
+++ b/src/modules/developer-guide/pages/corteza-server/index.adoc
@@ -17,7 +17,7 @@ Binary data is handled using minIO and stored either locally or on a supported c
 
 [CAUTION]
 ====
-{PRODUCT_NAME} server runs on GO 1.16.
+{PRODUCT_NAME} server runs on GO 1.19.
 This guide assumes that your GO development environment is already set up on the correct version.
 ====
 


### PR DESCRIPTION
Interestingly, Corteza 2024.9.2 seems to have switched to Go 1.24.1 instead (in a point release???) so I'm unsure if Go 1.19 or Go 1.24.1 should be used in this PR