### PR TITLE
Fix pgsql prod volume

### DIFF
--- a/src/modules/devops-guide/examples/deploy/prod-mysql/docker-compose.yaml
+++ b/src/modules/devops-guide/examples/deploy/prod-mysql/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     env_file: [ .env ]
     depends_on: [ db ]
     networks: [ proxy, internal ]
-    # Uncomment to use local fs for data persistence
+    # Uses local filesystem paths for data persistence
     volumes: [ "./data/server:/data" ]
     environment:
       # These two are needed only if you are using NginX Lets-Encrypt companion

--- a/src/modules/devops-guide/examples/deploy/prod-pgsql/docker-compose.yaml
+++ b/src/modules/devops-guide/examples/deploy/prod-pgsql/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
     image: postgres:15
     networks: [ internal ]
     restart: always
+    volumes: [ "./data/db:/var/lib/postgresql/data" ]
     healthcheck: { test: ["CMD-SHELL", "pg_isready -U corteza"], interval: 10s, timeout: 5s, retries: 5 }
     environment:
       # Warning: these are values that are only used on 1st start


### PR DESCRIPTION
Fixes #279.

Updates the production Docker Compose examples for data persistence.

Changes:
- Adds a PostgreSQL data volume mount to the production PostgreSQL deployment example.
- Clarifies the MySQL production server-volume comment because the mount is already active.

Current state checked:
- The MySQL production example already persists both server data and database data.
- The PostgreSQL production example already persists server data, but did not mount the PostgreSQL database directory.

This change adds:

./data/db:/var/lib/postgresql/data

to the PostgreSQL production deployment example so database data is persisted across container recreation and upgrades.